### PR TITLE
Adds reqs to montage.sub to run on SL6 and make montage.sub same across exercises

### DIFF
--- a/docs/materials/day1/part1-ex1-login.md
+++ b/docs/materials/day1/part1-ex1-login.md
@@ -21,7 +21,7 @@ To log in, use a [Secure Shell](http://en.wikipedia.org/wiki/Secure_Shell) (SSH)
 -   From a Mac or Linux computer, run the Terminal app and use the `ssh` command, like so:
 
 ``` console
-username@learn $ ssh %RED%<USERAME>%ENDCOLOR%@learn.chtc.wisc.edu
+username@learn $ ssh %RED%<USERNAME>%ENDCOLOR%@learn.chtc.wisc.edu
 ```
 
 -   On Windows, we recommend a free client called [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/), but any SSH client should be fine.

--- a/docs/materials/day1/part1-ex5-request.md
+++ b/docs/materials/day1/part1-ex5-request.md
@@ -57,7 +57,7 @@ The Resident Set Size (`RSS`) column, highlighted above, gives a rough indicatio
 Using `top`:
 
 ``` console
-username@learn $ top -u %RED%<USERAME>%ENDCOLOR%
+username@learn $ top -u %RED%<USERNAME>%ENDCOLOR%
 top - 13:55:31 up 11 days, 20:59,  5 users,  load average: 0.12, 0.12, 0.09
 Tasks: 198 total,   1 running, 197 sleeping,   0 stopped,   0 zombie
 Cpu(s):  1.2%us,  0.1%sy,  0.0%ni, 98.5%id,  0.2%wa,  0.0%hi,  0.1%si,  0.0%st

--- a/docs/materials/day1/part1-ex6-remove.md
+++ b/docs/materials/day1/part1-ex6-remove.md
@@ -50,7 +50,7 @@ Removing All of Your Jobs
 If you really want to remove all of your jobs at once, you can do that with:
 
 ```console
-username@learn $ condor_rm %RED%<USERAME>%ENDCOLOR%
+username@learn $ condor_rm %RED%<USERNAME>%ENDCOLOR%
 ```
 
 If you want to test it: (optional, though you'll likely need this in the future)

--- a/docs/materials/day1/part4-ex2-mandelbrot.md
+++ b/docs/materials/day1/part4-ex2-mandelbrot.md
@@ -76,6 +76,6 @@ If you're comfortable with `scp` or another method, you can copy it back to your
         :::console
         username@learn $ cp mandel.jpg ~/public_html/
 
-1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERAME>%ENDCOLOR% to your username on the submit machine).
+1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERNAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERNAME>%ENDCOLOR% to your username on the submit machine).
 
 

--- a/docs/materials/day1/part4-ex3-complex-dag.md
+++ b/docs/materials/day1/part4-ex3-complex-dag.md
@@ -25,8 +25,8 @@ log                     = goatbrot.log
 output                  = goatbrot.out.0.0
 error                   = goatbrot.err.0.0
 request_memory = 1GB
-request_disk       = 1GB
-request_cpus      = 1
+request_disk   = 1GB
+request_cpus   = 1
 queue
 ```
 
@@ -39,8 +39,8 @@ log                     = goatbrot.log
 output                  = goatbrot.out.0.1
 error                   = goatbrot.err.0.1
 request_memory = 1GB
-request_disk       = 1GB
-request_cpus      = 1
+request_disk   = 1GB
+request_cpus   = 1
 queue
 ```
 
@@ -53,8 +53,8 @@ log                     = goatbrot.log
 output                  = goatbrot.out.1.0
 error                   = goatbrot.err.1.0
 request_memory = 1GB
-request_disk       = 1GB
-request_cpus      = 1
+request_disk   = 1GB
+request_cpus   = 1
 queue
 ```
 
@@ -67,8 +67,8 @@ log                     = goatbrot.log
 output                  = goatbrot.out.1.1
 error                   = goatbrot.err.1.1
 request_memory = 1GB
-request_disk       = 1GB
-request_cpus      = 1
+request_disk   = 1GB
+request_cpus   = 1
 queue
 ```
 
@@ -84,8 +84,9 @@ output                  = montage.out
 error                   = montage.err
 log                     = montage.log
 request_memory = 1GB
-request_disk       = 1GB
-request_cpus      = 1
+request_disk   = 1GB
+request_cpus   = 1
+requirements = OpSysMajorVer =?= 6
 queue
 ```
 

--- a/docs/materials/day1/part4-ex4-failed-dag.md
+++ b/docs/materials/day1/part4-ex4-failed-dag.md
@@ -17,18 +17,17 @@ Breaking Things
 
 Recall that DAGMan decides that a jobs fails if its exit code is non-zero. Let's modify our montage job so that it fails. Work in the same directory where you did the last DAG. Edit montage.sub to add a `-h` to the arguments. It will look like this (the change is highlighted in red):
 
-``` console
-universe                = vanilla
+``` file
 executable              = /usr/bin/montage
-arguments               = %RED%-h%ENDCOLOR% tile_0_0.ppm tile_0_1.ppm tile_1_0.ppm tile_1_1.ppm -mode Concatenate -tile 2x2 mandle.jpg
+arguments               = %RED%-h%ENDCOLOR% tile_0_0.ppm tile_0_1.ppm tile_1_0.ppm tile_1_1.ppm -mode Concatenate -tile 2x2 mandle-from-dag.jpg
 transfer_input_files    = tile_0_0.ppm,tile_0_1.ppm,tile_1_0.ppm,tile_1_1.ppm
-transfer_executable     = false
 output                  = montage.out
 error                   = montage.err
-log                     = goat.log
-request_memory = 1G
-request_disk       = 1G
-request_cpus      = 1
+log                     = montage.log
+request_memory = 1GB
+request_disk   = 1GB
+request_cpus   = 1
+requirements = OpSysMajorVer =?= 6
 queue
 ```
 


### PR DESCRIPTION
(ATTN @lmichael107 )

Also fixes minor typos (s/USERAME/USERNAME/) and minor formatting weirdness.

`/usr/bin/montage` has problems with libs on CentOS7. We should fix this for next year when the pool should be running ~100% CentOS7.