### PR TITLE
Skip linkchecker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 install: pip install -r ci/pip-requirements.txt
 script:
-- ./ci/verify
+- ./ci/verify -s
 - ./ci/deploy


### PR DESCRIPTION
So we don't have to wait when we need to fix things realtime. For those of you making major updates to content, you'll want to run the linkchecker on your own. To do this, run the following from the root of your clone:

```
ci/verify
```